### PR TITLE
17 add interest tags to database schema

### DIFF
--- a/backend/prisma/migrations/20250922152552_init/migration.sql
+++ b/backend/prisma/migrations/20250922152552_init/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "public"."Tag" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."_UserTags" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_UserTags_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_name_key" ON "public"."Tag"("name");
+
+-- CreateIndex
+CREATE INDEX "_UserTags_B_index" ON "public"."_UserTags"("B");
+
+-- AddForeignKey
+ALTER TABLE "public"."_UserTags" ADD CONSTRAINT "_UserTags_A_fkey" FOREIGN KEY ("A") REFERENCES "public"."Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."_UserTags" ADD CONSTRAINT "_UserTags_B_fkey" FOREIGN KEY ("B") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -10,7 +10,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url      = env("DATABASE_URL") //env("DATABASE_URL"). What is there now is to test locally
 }
 
 // User Table
@@ -19,6 +19,7 @@ model User {
   email      String     @unique
   password   String // hashed with bcrypt, not plain text
   name       String?
+ 
   status     UserStatus @default(AVAILABLE)
   visibility Boolean    @default(true)
   trustScore Decimal    @default(0.0)
@@ -30,7 +31,8 @@ model User {
   wavesSent      Wave[]    @relation("WavesSent")
   wavesRecv      Wave[]    @relation("WavesReceived")
   reportsMade    Report[]  @relation("ReportsMade")
-  reportsAgainst Report[]  @relation("ReportsAgainst")
+  reportsAgainst Report[]  @relation("ReportsAgainst") 
+  tags Tag[] @relation("UserTags") //User interests
 }
 
 enum UserStatus {
@@ -66,4 +68,10 @@ model Report {
   reportedId Int
   reporter   User     @relation("ReportsMade", fields: [reporterId], references: [id])
   reported   User     @relation("ReportsAgainst", fields: [reportedId], references: [id])
+}
+
+model Tag {
+  id  Int @id @default(autoincrement())
+  name String @unique
+  users User[] @relation("UserTags") //allows for relation between users and tags via a join tab
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,6 @@ app.get("/", (_req, res) => {
 });
 
 // Mount user routes
-app.use(usersRouter);
+app.use("/api", usersRouter);
 
 export default app;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import usersRouter from "./routes/users.routes";
+import tagsRouter from "./routes/tags.routes";
 
 const app = express();
 
@@ -13,5 +14,8 @@ app.get("/", (_req, res) => {
 
 // Mount user routes
 app.use("/api", usersRouter);
+
+// Mount tag routes
+app.use("/api", tagsRouter);
 
 export default app;

--- a/backend/src/controllers/tags.controller.ts
+++ b/backend/src/controllers/tags.controller.ts
@@ -1,0 +1,90 @@
+import { Request, Response } from "express";
+import prisma from "../prisma";
+
+// Create a tag
+export const createTag = async (req: Request, res: Response) => {
+  try {
+    const { name } = req.body;
+    if (!name) return res.status(400).json({ error: "Tag name is required" });
+
+    const tag = await prisma.tag.create({ data: { name } });
+    res.status(201).json(tag);
+  } catch (error: any) {
+    if (error.code === "P2002") {
+      return res.status(400).json({ error: "Tag already exists" });
+    }
+    res.status(500).json({ error: "Failed to create tag" });
+  }
+};
+
+// Get all tags
+export const getTags = async (_req: Request, res: Response) => {
+  try {
+    const tags = await prisma.tag.findMany();
+    res.json(tags);
+  } catch (error) {
+    res.status(500).json({ error: "Failed to fetch tags" });
+  }
+};
+
+// Get one tag by ID
+export const getTagById = async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: "Invalid tag ID" });
+    }
+
+    const tag = await prisma.tag.findUnique({ where: { id } });
+    if (!tag) return res.status(404).json({ error: "Tag not found" });
+
+    res.json(tag);
+  } catch (error) {
+    res.status(500).json({ error: "Failed to fetch tag" });
+  }
+};
+
+// Update a tag
+export const updateTag = async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id);
+    const { name } = req.body;
+
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: "Invalid tag ID" });
+    }
+    if (!name) {
+      return res.status(400).json({ error: "Tag name is required" });
+    }
+
+    const tag = await prisma.tag.update({
+      where: { id },
+      data: { name },
+    });
+
+    res.json(tag);
+  } catch (error: any) {
+    if (error.code === "P2025") {
+      return res.status(404).json({ error: "Tag not found" });
+    }
+    res.status(500).json({ error: "Failed to update tag" });
+  }
+};
+
+// Delete a tag
+export const deleteTag = async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: "Invalid tag ID" });
+    }
+
+    await prisma.tag.delete({ where: { id } });
+    res.status(204).send(); // no content
+  } catch (error: any) {
+    if (error.code === "P2025") {
+      return res.status(404).json({ error: "Tag not found" });
+    }
+    res.status(500).json({ error: "Failed to delete tag" });
+  }
+};

--- a/backend/src/controllers/users.controller.ts
+++ b/backend/src/controllers/users.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import prisma from "../prisma";
+import { getAllUsers, addTagToUser, findUsersByTag } from '../services/users.services';
 
 // Create a new user
 export const createUser = async (req: Request, res: Response) => {
@@ -92,5 +93,51 @@ export const deleteUser = async (req: Request, res: Response) => {
     }
     console.error(err);
     res.status(500).json({ error: "Failed to delete user" });
+  }
+};
+
+// GET /api/users
+export const listUsers = async (_req: Request, res: Response) => {
+  try {
+    const users = await getAllUsers();
+    res.json(users);
+  } catch (error) {
+    console.error('Error listing users:', error);
+    res.status(500).json({ error: 'Failed to list users' });
+  }
+};
+
+// POST /api/users/:id/tags
+export const addTag = async (req: Request, res: Response) => {
+  try {
+    const userId = Number(req.params.id);
+    const { tagName } = req.body;
+
+    if (!tagName) {
+      return res.status(400).json({ error: 'tagName is required' });
+    }
+
+    const user = await addTagToUser(userId, tagName);
+    res.json(user);
+  } catch (error) {
+    console.error('Error adding tag to user:', error);
+    res.status(500).json({ error: 'Failed to add tag to user' });
+  }
+};
+
+// GET /api/users/tags/:tagName
+export const getUsersByTag = async (req: Request, res: Response) => {
+  try {
+    const tagName = req.params.tagName;
+
+    if (!tagName) {
+      return res.status(400).json({ error: 'tagName parameter is required' });
+    }
+
+    const users = await findUsersByTag(tagName);
+    res.json(users);
+  } catch (error) {
+    console.error('Error finding users by tag:', error);
+    res.status(500).json({ error: 'Failed to find users by tag' });
   }
 };

--- a/backend/src/controllers/users.controller.ts
+++ b/backend/src/controllers/users.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import prisma from "../prisma";
-import { getAllUsers, addTagToUser, findUsersByTag } from '../services/users.services';
+import { getAllUsers, addTagToUser, findUsersByTag } from "../services/users.services";
 
 // Create a new user
 export const createUser = async (req: Request, res: Response) => {
@@ -96,48 +96,80 @@ export const deleteUser = async (req: Request, res: Response) => {
   }
 };
 
-// GET /api/users
+// List all user: GET /api/users
 export const listUsers = async (_req: Request, res: Response) => {
   try {
     const users = await getAllUsers();
     res.json(users);
   } catch (error) {
-    console.error('Error listing users:', error);
-    res.status(500).json({ error: 'Failed to list users' });
+    console.error("Error listing users:", error);
+    res.status(500).json({ error: "Failed to list users" });
   }
 };
 
-// POST /api/users/:id/tags
+// Add tag to a specific user: POST /api/users/:id/tags
 export const addTag = async (req: Request, res: Response) => {
   try {
     const userId = Number(req.params.id);
     const { tagName } = req.body;
 
     if (!tagName) {
-      return res.status(400).json({ error: 'tagName is required' });
+      return res.status(400).json({ error: "tagName is required" });
     }
 
     const user = await addTagToUser(userId, tagName);
     res.json(user);
   } catch (error) {
-    console.error('Error adding tag to user:', error);
-    res.status(500).json({ error: 'Failed to add tag to user' });
+    console.error("Error adding tag to user:", error);
+    res.status(500).json({ error: "Failed to add tag to user" });
   }
 };
 
-// GET /api/users/tags/:tagName
+// Look for Users with a tag: GET /api/users/tags/:tagName
 export const getUsersByTag = async (req: Request, res: Response) => {
   try {
     const tagName = req.params.tagName;
 
     if (!tagName) {
-      return res.status(400).json({ error: 'tagName parameter is required' });
+      return res.status(400).json({ error: "tagName parameter is required" });
     }
 
     const users = await findUsersByTag(tagName);
     res.json(users);
   } catch (error) {
-    console.error('Error finding users by tag:', error);
-    res.status(500).json({ error: 'Failed to find users by tag' });
+    console.error("Error finding users by tag:", error);
+    res.status(500).json({ error: "Failed to find users by tag" });
   }
 };
+//Remove a tag from a user: DELETE /api/users/:id/tags/:tagName
+export const deleteTagFromUser = async (req: Request, res: Response) => {
+  try {
+    const userId = Number(req.params.id);
+    const { tagName } = req.body;
+
+    if (Number.isNaN(userId)) {
+      return res.status(400).json({ error: "Invalid user ID" });
+    }
+    if (!tagName) {
+      return res.status(400).json({ error: "tagName is required" });
+    }
+
+    const user = await prisma.user.update({
+      where: { id: userId },
+      data: {
+        tags: {
+          disconnect: { name: tagName }, // remove the relation
+        },
+      },
+      include: { tags: true }, // return updated user with tags
+    });
+
+    res.json(user);
+  } catch (error: any) {
+    console.error("Error removing tag from user:", error);
+    if (error.code === "P2025") {
+      return res.status(404).json({ error: "User or tag not found" });
+    }
+    res.status(500).json({ error: "Failed to remove tag from user" });
+  }
+}

--- a/backend/src/routes/tags.routes.ts
+++ b/backend/src/routes/tags.routes.ts
@@ -1,0 +1,17 @@
+import express from "express";
+import {
+    createTag, 
+    getTags, 
+    getTagById, 
+    updateTag, 
+    deleteTag } from "../controllers/tags.controller";
+
+const router = express.Router();
+
+router.post("/tags", createTag);      // Create a tag
+router.get("/tags", getTags);         // Read all tags
+router.get("/tags/:id", getTagById);   // Read one tag
+router.put("/tags/:id", updateTag);    // Update a tag
+router.delete("/tags/:id", deleteTag); // Delete a tag
+
+export default router;

--- a/backend/src/routes/users.routes.ts
+++ b/backend/src/routes/users.routes.ts
@@ -5,6 +5,9 @@ import {
   getUserById,
   updateUser,
   deleteUser,
+  listUsers, 
+  addTag, 
+  getUsersByTag
 } from "../controllers/users.controller";
 
 const router = Router();
@@ -15,5 +18,8 @@ router.get("/users", getUsers);
 router.get("/users/:id", getUserById);
 router.patch("/users/:id", updateUser);
 router.delete("/users/:id", deleteUser);
+router.get("/users", listUsers);
+router.post("/users/:id/tags", addTag);
+router.get("/users/tags/:tagName", getUsersByTag);
 
 export default router;

--- a/backend/src/routes/users.routes.ts
+++ b/backend/src/routes/users.routes.ts
@@ -7,7 +7,8 @@ import {
   deleteUser,
   listUsers, 
   addTag, 
-  getUsersByTag
+  getUsersByTag,
+  deleteTagFromUser
 } from "../controllers/users.controller";
 
 const router = Router();
@@ -19,7 +20,8 @@ router.get("/users/:id", getUserById);
 router.patch("/users/:id", updateUser);
 router.delete("/users/:id", deleteUser);
 router.get("/users", listUsers);
-router.post("/users/:id/tags", addTag);
-router.get("/users/tags/:tagName", getUsersByTag);
+router.post("/users/:id/tags", addTag);                //Add tag to a user
+router.get("/users/tags/:tagName", getUsersByTag);     //Get users by tag
+router.delete("/users/:id/tags/:tagName", deleteTagFromUser); //Remove a tag from a user
 
 export default router;

--- a/backend/src/services/users.services.ts
+++ b/backend/src/services/users.services.ts
@@ -1,0 +1,57 @@
+import prisma from '../prisma';
+import { Prisma } from '@prisma/client';
+
+// Get all users with their tags
+export const getAllUsers = async () => {
+  try {
+    const users = await prisma.user.findMany({
+      include: { tags: true },
+    });
+    return users;
+  } catch (error) {
+    console.error('Prisma error in getAllUsers:', error);
+    throw new Error('Failed to fetch users');
+  }
+};
+
+// Add a tag to a user (creates tag if it doesn't exist)
+export const addTagToUser = async (userId: number, tagName: string) => {
+  try {
+    const user = await prisma.user.update({
+      where: { id: userId },
+      data: {
+        tags: {
+          connectOrCreate: {
+            where: { name: tagName },
+            create: { name: tagName },
+          },
+        },
+      },
+      include: { tags: true },
+    });
+    return user;
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      console.error('Prisma known request error in addTagToUser:', error);
+    } else {
+      console.error('Unknown error in addTagToUser:', error);
+    }
+    throw new Error('Failed to add tag to user');
+  }
+};
+
+// Find users who have a certain tag
+export const findUsersByTag = async (tagName: string) => {
+  try {
+    const users = await prisma.user.findMany({
+      where: {
+        tags: { some: { name: tagName } },
+      },
+      include: { tags: true },
+    });
+    return users;
+  } catch (error) {
+    console.error('Prisma error in findUsersByTag:', error);
+    throw new Error('Failed to find users by tag');
+  }
+};


### PR DESCRIPTION
Tag implementation: Tags are created as their own table, with params id and name and an array of users. Every tag has a unique id number attached to them. For every tag added to a user, a new entry is added to a relational table "_UserTags", which shows the relation between a user and a tag. I also added a new fiend to users, which is basically an array of tags. 

I felt this approach better than just implementing a string array to users as it allows for some pretty interesting stuff, like finding all users with a specific tag. All crud methods have been tested by me using a private database, so I can assure that the implementation works.